### PR TITLE
feat: implement keycloak infra and security

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,80 @@
+# Book Me - Gateway Service
+BookMe manages bookings and this service is the api-gateway service for the BookMe application.
+
+---
+
+## 🔧 Local Dev Testing Setup (Local + Port-Forwarding) for Keycloak
+
+This guide helps you run the API Gateway and access Keycloak locally for token-based authentication using `kubectl port-forward`.
+
+---
+
+### 📦 Prerequisites
+
+- A running Kubernetes cluster (e.g., Minikube or Docker Desktop)
+- `kubectl` installed and configured
+- Keycloak running as a Kubernetes service named: `keycloak-service`
+- API Gateway deployed to the cluster
+
+---
+
+### ✅ Step-by-Step Setup
+
+#### 1. 📌 Port-forward Keycloak to your local machine
+
+```bash
+kubectl port-forward svc/keycloak-service 8181:8080
+```
+Keycloak will now be accessible at:
+http://localhost:8181
+
+#### 2. ⚙️ Set the Keycloak Frontend URL
+In the Keycloak Admin Console:
+
+- Navigate to: Realm Settings → General
+- Set the Frontend URL to: 
+ ```http
+http://keycloak-service:8080
+```
+
+This ensures tokens have the correct iss (issuer) claim expected by the API Gateway. 
+Hence, you will have the iss claim in JWT as "http://keycloak-service:8080/realms/bookme-realm"
+
+#### 3. ⚙️ Verify API Gateway JWT Configuration
+Ensure your API Gateway's configuration includes the correct issuer URI. 
+For example, in application.yml or your deployment environment variables:
+```KEYCLOAK_JWT_ISSUER_URI=http://keycloak-service:8080/realms/bookme-realm```
+>>**Important**: Use the internal service URL here (keycloak-service:8080), not localhost. The gateway runs inside the cluster and resolves the service name internally.
+
+
+#### 4. 🧪 Get an Access Token via Postman
+In Postman, configure the OAuth2 token request with:
+- Access Token URL:
+  ```http://localhost:8181/realms/bookme-realm/protocol/openid-connect/token```
+- Provide:
+  - client_id
+  - client_secret
+  - Grant type (i.e. client_credentials) - Use client_credentials grant for service-to-service flow.
+
+    The above steps will obtain a valid JWT token for testing.
+
+
+#### 5. 📬 Port-forward the API Gateway (if not already done)
+```bash
+kubectl port-forward svc/gateway-service 9000:9000
+```
+The API Gateway will now be accessible at:
+```http://localhost:9000```
+
+
+#### 6. ✅ Make API Requests with Bearer Token
+Use Postman or curl to call your API through the gateway with the token:
+```bash
+curl -H "Authorization: Bearer <access-token>" http://localhost:9000/bookings
+```
+Or in Postman:
+
+- URL: http://localhost:9000/bookings
+- Add header: Authorization: Bearer <access-token>
+
+>ℹ️ This setup is intended for local development and testing only. For production, consider exposing Keycloak via an Ingress or external DNS endpoint.

--- a/k8s/api-gateway/gateway-app.yaml
+++ b/k8s/api-gateway/gateway-app.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: gateway-service
-          image: isaacafrifa/bm-api-gateway:0.0.1-SNAPSHOT-20250119-2050
+          image: isaacafrifa/bm-api-gateway:0.0.1-SNAPSHOT-20250518-2022
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 9000
@@ -116,18 +116,39 @@ spec:
                 configMapKeyRef:
                   name: infra-config
                   key: MANAGEMENT_ZIPKIN_TRACING_ENDPOINT
+            ## keycloak
+            - name: KEYCLOAK_JWT_ISSUER_URI
+              valueFrom:
+                configMapKeyRef:
+                  name: infra-config
+                  key: KEYCLOAK_JWT_ISSUER_URI
+            - name: KEYCLOAK_JWK_SET_URI
+              valueFrom:
+                configMapKeyRef:
+                  name: infra-config
+                  key: KEYCLOAK_JWK_SET_URI
+          # Lower resources ideal for local dev. Update when doing heavy processing or caching.
+          resources:
+            requests:
+              memory: "300Mi"
+              cpu: "200m"
+            limits:
+              memory: "600Mi"
+              cpu: "500m"
+         # Lower resource limits may lead to slow boot (~60s+); adjust readiness/liveness probes accordingly
           livenessProbe:
             httpGet:
               path: /actuator/health
               port: 9000
-            initialDelaySeconds: 30
-            periodSeconds: 10
+            initialDelaySeconds: 120  # Gives app plenty of time to start
+            periodSeconds: 10  # Checks every 10 seconds
+            failureThreshold: 3 # Restarts after 3 failures (30 seconds)
           readinessProbe:
             httpGet:
               path: /actuator/health
               port: 9000
-            initialDelaySeconds: 10
-            periodSeconds: 5
+            initialDelaySeconds: 30 # Shorter delay - starts checking sooner
+            periodSeconds: 5  # More frequent checks
   strategy:
     # RollingUpdate strategy ensures zero-downtime during deployments by gradually updating pods
     type: RollingUpdate

--- a/k8s/infra/infra-config.yaml
+++ b/k8s/infra/infra-config.yaml
@@ -19,3 +19,5 @@ data:
   GATEWAY_SERVICE_URL: "http://gateway-service.default.svc.cluster.local:9000"
   # Keycloak
   KEYCLOAK_DB_NAME: "keycloak-db"
+  KEYCLOAK_JWT_ISSUER_URI: "http://keycloak-service:8080/realms/bookme-realm"
+  KEYCLOAK_JWK_SET_URI: "http://keycloak-service:8080/realms/bookme-realm/protocol/openid-connect/certs"

--- a/k8s/infra/infra-config.yaml
+++ b/k8s/infra/infra-config.yaml
@@ -17,3 +17,5 @@ data:
   BOOKING_SERVICE_URL: "http://booking-service.default.svc.cluster.local:8081"
   # API-Gateway Service
   GATEWAY_SERVICE_URL: "http://gateway-service.default.svc.cluster.local:9000"
+  # Keycloak
+  KEYCLOAK_DB_NAME: "keycloak"

--- a/k8s/infra/infra-config.yaml
+++ b/k8s/infra/infra-config.yaml
@@ -18,4 +18,4 @@ data:
   # API-Gateway Service
   GATEWAY_SERVICE_URL: "http://gateway-service.default.svc.cluster.local:9000"
   # Keycloak
-  KEYCLOAK_DB_NAME: "keycloak"
+  KEYCLOAK_DB_NAME: "keycloak-db"

--- a/k8s/infra/keycloak/keycloak-app.yaml
+++ b/k8s/infra/keycloak/keycloak-app.yaml
@@ -74,29 +74,27 @@ spec:
               value: "true"
 #            - name: KC_LOG_LEVEL
 #              value: "DEBUG"
-#            - name: KC_HTTP_PORT
-#              value: "8080"
-#            - name: JAVA_OPTS_APPEND
-#              value: "-Dcom.sun.jndi.ldap.object.disableEndpointIdentification=true"
+#        Keycloak is memory-hungry, especially with multiple realms or clients. It's JVM-based, so 512Mi–1Gi is a safe lower bound for dev.
           resources:
             requests:
               memory: "512Mi"
-              cpu: "500m"
+              cpu: "200m"
             limits:
               memory: "1Gi"
-              cpu: "1"
+              cpu: "500m"
+          # Lower resource limits may lead to slow boot (~60s+); adjust readiness/liveness probes accordingly
           readinessProbe:
             httpGet:
               path: /health/ready
               port: 8080
-            initialDelaySeconds: 30
+            initialDelaySeconds: 90 # increased to account for lower resource limits
             periodSeconds: 10
             failureThreshold: 3
           livenessProbe:
             httpGet:
               path: /health/live
               port: 8080
-            initialDelaySeconds: 30
+            initialDelaySeconds: 90
             periodSeconds: 10
             failureThreshold: 3
   strategy:

--- a/k8s/infra/keycloak/keycloak-app.yaml
+++ b/k8s/infra/keycloak/keycloak-app.yaml
@@ -2,19 +2,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: keycloak
+  name: keycloak-app
   labels:
     app: keycloak # groups this deployment with other Keycloak-related resources
+    tier: backend
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: keycloak # tells k8s which pods it should manage. This MUST match the template labels
+      tier: backend
   template:
     metadata:
-      name: keycloak
       labels:
         app: keycloak # defines what labels the pods will have when created. This MUST match the selector above
+        tier: backend
     spec:
       containers:
         - name: keycloak
@@ -22,7 +24,7 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
-          args: ["start-dev"] # Add this for development mode
+          args: ["start-dev"] # Starts Keycloak in development mode (no TLS, faster startup)
           env:
             - name: KEYCLOAK_ADMIN
               valueFrom:
@@ -36,7 +38,7 @@ spec:
                   key: KEYCLOAK_ADMIN_PASSWORD
             # Keycloak DB Config
             - name: KC_DB
-              value: "postgres"  # or "mysql" depending on your database
+              value: "postgres" # Sets Keycloak's DB vendor (supports: postgres, mysql, etc.)
             - name: KC_DB_URL
               value: "jdbc:postgresql://keycloak-db-service:5432/${KC_DB_DATABASE}"  # adjust host and port as needed
             - name: KC_DB_DATABASE
@@ -62,7 +64,7 @@ spec:
               value: "false"
             - name: KC_HTTP_ENABLED # Enables HTTP (instead of HTTPS only)
               value: "true"
-            - name: KC_PROXY # Configures proxy behavior; edge is fine for dev and Ingress setups
+            - name: KC_PROXY # Configures proxy behavior; required when running behind a reverse proxy (like ingress)
               value: "edge"
             - name: KC_HEALTH_ENABLED # Enables /health/live and /health/ready endpoints
               value: "true"
@@ -70,8 +72,12 @@ spec:
               value: "true"
             - name: PROXY_ADDRESS_FORWARDING # Important when running behind proxies like Ingress; may affect token redirects (Optional in port-forward. Recommended for Ingress)
               value: "true"
-          # - name: KC_LOG_LEVEL
-          #   value: "DEBUG"
+#            - name: KC_LOG_LEVEL
+#              value: "DEBUG"
+#            - name: KC_HTTP_PORT
+#              value: "8080"
+#            - name: JAVA_OPTS_APPEND
+#              value: "-Dcom.sun.jndi.ldap.object.disableEndpointIdentification=true"
           resources:
             requests:
               memory: "512Mi"
@@ -113,13 +119,13 @@ metadata:
   name: keycloak-service
   labels:
     app: keycloak # groups this service with other Keycloak-related resources
+    tier: backend
 spec:
   selector:
     app: keycloak # Matches Deployment's label
+    tier: backend
   type: ClusterIP
   ports:
     - protocol: TCP
-      port: 8080 # The port other services use to access
-      targetPort: 8080
-
-      
+      port: 8080 # Port that other services in the cluster will use to connect to this service
+      targetPort: 8080 # Port on the Keycloak container where the application is actually running

--- a/k8s/infra/keycloak/keycloak-db.yaml
+++ b/k8s/infra/keycloak/keycloak-db.yaml
@@ -7,19 +7,24 @@ metadata:
   name: keycloak-db
   labels:
     app: keycloak  # Label that identifies this as part of the Keycloak application group
+    tier: database # Label that identifies this as part of the Keycloak database tier
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: keycloak # Selector for identifying which Pods this Deployment manages - must match Pod template labels below
+      tier: database
   template: # Template contains the blueprint for pods
     metadata:
       labels:
         app: keycloak # Label applied to Pods - must match Deployment selector above and Service selector below
+        tier: database
     spec:
       containers:
         - name: keycloak-db
           image: postgres:16.1
+          ports:
+            - containerPort: 5432
           env:
             - name: POSTGRES_DB
               valueFrom:
@@ -36,15 +41,16 @@ spec:
                 secretKeyRef:
                   name: infra-secrets
                   key: KEYCLOAK_DB_PASSWORD
-          ports:
-            - containerPort: 5432
           volumeMounts:
             - mountPath: /var/lib/postgresql/data
               name: keycloak-data
+              subPath: postgres # This helps avoid unintended overwrites when multiple PVCs are reused.
       volumes:
         - name: keycloak-data # Volume name that corresponds to volumeMount above
           persistentVolumeClaim:
             claimName: keycloak-db-pvc # references the PVC in 'keycloak-storage.yaml'
+      securityContext:
+        fsGroup: 999 # Ensures the Postgres process (running as UID 999) can write to mounted volumes
 
 ---
 
@@ -55,6 +61,7 @@ metadata:
   name: keycloak-db-service
   labels:
     app: keycloak # Label that identifies this service as part of the Keycloak application group
+    tier: database
 spec:
   type: ClusterIP # Internal cluster access only - not exposed externally
   ports:
@@ -62,3 +69,4 @@ spec:
       targetPort: 5432
   selector:
     app: keycloak # Selects Pods with matching label to receive traffic from this Service
+    tier: database

--- a/k8s/infra/keycloak/keycloak-db.yaml
+++ b/k8s/infra/keycloak/keycloak-db.yaml
@@ -6,16 +6,16 @@ kind: Deployment
 metadata:
   name: keycloak-db
   labels:
-    app: keycloak  # groups this database deployment with other Keycloak-related resources
+    app: keycloak  # Label that identifies this as part of the Keycloak application group
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: keycloak-db # tells Kubernetes which pods it should manage. This MUST match the template labels
+      app: keycloak # Selector for identifying which Pods this Deployment manages - must match Pod template labels below
   template: # Template contains the blueprint for pods
     metadata:
       labels:
-        app: keycloak-db #defines what labels the pods will have when created. This MUST match the selector above
+        app: keycloak # Label applied to Pods - must match Deployment selector above and Service selector below
     spec:
       containers:
         - name: keycloak-db
@@ -42,7 +42,7 @@ spec:
             - mountPath: /var/lib/postgresql/data
               name: keycloak-data
       volumes:
-        - name: keycloak-data # matches volumeMounts name above
+        - name: keycloak-data # Volume name that corresponds to volumeMount above
           persistentVolumeClaim:
             claimName: keycloak-db-pvc # references the PVC in 'keycloak-storage.yaml'
 
@@ -54,11 +54,11 @@ kind: Service
 metadata:
   name: keycloak-db-service
   labels:
-    app: keycloak # groups this database service with other Keycloak-related resources
+    app: keycloak # Label that identifies this service as part of the Keycloak application group
 spec:
-  type: ClusterIP # Only expose the db inside the cluster
+  type: ClusterIP # Internal cluster access only - not exposed externally
   ports:
     - port: 5432
       targetPort: 5432
   selector:
-    app: keycloak-db # Matches Deployment's label
+    app: keycloak # Selects Pods with matching label to receive traffic from this Service

--- a/k8s/infra/keycloak/keycloak-db.yaml
+++ b/k8s/infra/keycloak/keycloak-db.yaml
@@ -1,0 +1,64 @@
+# Keycloak will use a database for persistence, hence this manifest file
+
+# Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keycloak-db
+  labels:
+    app: keycloak  # groups this database deployment with other Keycloak-related resources
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: keycloak-db # tells Kubernetes which pods it should manage. This MUST match the template labels
+  template: # Template contains the blueprint for pods
+    metadata:
+      labels:
+        app: keycloak-db #defines what labels the pods will have when created. This MUST match the selector above
+    spec:
+      containers:
+        - name: keycloak-db
+          image: postgres:16.1
+          env:
+            - name: POSTGRES_DB
+              valueFrom:
+                configMapKeyRef:
+                  name: infra-config
+                  key: KEYCLOAK_DB_NAME
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: infra-secrets
+                  key: KEYCLOAK_DB_USERNAME
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: infra-secrets
+                  key: KEYCLOAK_DB_PASSWORD
+          ports:
+            - containerPort: 5432
+          volumeMounts:
+            - mountPath: /var/lib/postgresql/data
+              name: keycloak-data
+      volumes:
+        - name: keycloak-data # matches volumeMounts name above
+          persistentVolumeClaim:
+            claimName: keycloak-db-pvc # references the PVC in 'keycloak-storage.yaml'
+
+---
+
+# Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-db-service
+  labels:
+    app: keycloak # groups this database service with other Keycloak-related resources
+spec:
+  type: ClusterIP # Only expose the db inside the cluster
+  ports:
+    - port: 5432
+      targetPort: 5432
+  selector:
+    app: keycloak-db # Matches Deployment's label

--- a/k8s/infra/keycloak/keycloak-db.yaml
+++ b/k8s/infra/keycloak/keycloak-db.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: keycloak-db
-          image: postgres:16.1
+          image: postgres:16.1-alpine # Lightweight Alpine-based image, perfect for local dev where minimal resource usage is required
           ports:
             - containerPort: 5432
           env:
@@ -41,6 +41,14 @@ spec:
                 secretKeyRef:
                   name: infra-secrets
                   key: KEYCLOAK_DB_PASSWORD
+          ## Small, conservative resource values — enough for basic CRUD
+          resources:
+            requests:
+              memory: "150Mi"
+              cpu: "100m"
+            limits:
+              memory: "300Mi"
+              cpu: "200m"
           volumeMounts:
             - mountPath: /var/lib/postgresql/data
               name: keycloak-data

--- a/k8s/infra/keycloak/keycloak-storage.yaml
+++ b/k8s/infra/keycloak/keycloak-storage.yaml
@@ -20,6 +20,7 @@ spec:
   storageClassName: standard  # Default storage class in Minikube
   hostPath:   # For Minikube, uses local machine storage
     path: "/data/keycloak-db"  # Directory on your host machine
+    type: DirectoryOrCreate # Creates the directory on the host if it doesn't exist (used with hostPath)
 
 
 ---
@@ -31,7 +32,6 @@ metadata:
   name: keycloak-db-pvc
   namespace: default # using the default namespace :)
   labels:
-    type: local
     app: keycloak # Consistent labeling with PV for better resource tracking
 spec:
   accessModes:

--- a/k8s/infra/keycloak/keycloak-storage.yaml
+++ b/k8s/infra/keycloak/keycloak-storage.yaml
@@ -1,0 +1,44 @@
+# Keycloak will use a database for persistence. Hence, we need to create a
+# persistent volume and persistent volume claim for the database.
+
+# Define the PersistentVolume first
+# PersistentVolume
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: keycloak-db-pv
+  labels: # let's use labels here to help identify and organize Kubernetes resources
+    type: local #'type: local' indicates this storage is local to the cluster
+    app: keycloak # 'app: keycloak' associates this volume with the Keycloak application
+spec:
+  capacity:
+    storage: 500Mi
+  volumeMode: Filesystem # default and most common mode
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain # Keeps data when PVC is deleted
+  storageClassName: standard  # Default storage class in Minikube
+  hostPath:   # For Minikube, uses local machine storage
+    path: "/data/keycloak-db"  # Directory on your host machine
+
+
+---
+
+# PersistentVolumeClaim
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: keycloak-db-pvc
+  namespace: default # using the default namespace :)
+  labels:
+    type: local
+    app: keycloak # Consistent labeling with PV for better resource tracking
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      # Request half a gigabyte of storage
+      # Can be increased but not decreased after creation
+      storage: 500Mi #1Gi
+  storageClassName: standard # Must match PV's storageClassName. 'standard' is the default storage class

--- a/k8s/infra/keycloak/keycloak.yaml
+++ b/k8s/infra/keycloak/keycloak.yaml
@@ -1,0 +1,125 @@
+# Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keycloak
+  labels:
+    app: keycloak # groups this deployment with other Keycloak-related resources
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: keycloak # tells k8s which pods it should manage. This MUST match the template labels
+  template:
+    metadata:
+      name: keycloak
+      labels:
+        app: keycloak # defines what labels the pods will have when created. This MUST match the selector above
+    spec:
+      containers:
+        - name: keycloak
+          image: quay.io/keycloak/keycloak:24.0.1
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          args: ["start-dev"] # Add this for development mode
+          env:
+            - name: KEYCLOAK_ADMIN
+              valueFrom:
+                secretKeyRef:
+                  name: infra-secrets
+                  key: KEYCLOAK_ADMIN_USERNAME
+            - name: KEYCLOAK_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: infra-secrets
+                  key: KEYCLOAK_ADMIN_PASSWORD
+            # Keycloak DB Config
+            - name: KC_DB
+              value: "postgres"  # or "mysql" depending on your database
+            - name: KC_DB_URL
+              value: "jdbc:postgresql://keycloak-db-service:5432/${KC_DB_DATABASE}"  # adjust host and port as needed
+            - name: KC_DB_DATABASE
+              valueFrom:
+                configMapKeyRef:
+                  name: infra-config
+                  key: KEYCLOAK_DB_NAME
+            - name: KC_DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: infra-secrets
+                  key: KEYCLOAK_DB_USERNAME
+            - name: KC_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: infra-secrets
+                  key: KEYCLOAK_DB_PASSWORD
+
+            # Other Keycloak Config
+            - name: KC_HOSTNAME_STRICT # Disables strict hostname checks (allows access via any host e.g. localhost)
+              value: "false"
+            - name: KC_HOSTNAME_STRICT_HTTPS
+              value: "false"
+            - name: KC_HTTP_ENABLED # Enables HTTP (instead of HTTPS only)
+              value: "true"
+            - name: KC_PROXY # Configures proxy behavior; edge is fine for dev and Ingress setups
+              value: "edge"
+            - name: KC_HEALTH_ENABLED # Enables /health/live and /health/ready endpoints
+              value: "true"
+            - name: KC_METRICS_ENABLED # Enables Prometheus metrics at /metrics (remove if you’re not using monitoring)
+              value: "true"
+            - name: PROXY_ADDRESS_FORWARDING # Important when running behind proxies like Ingress; may affect token redirects (Optional in port-forward. Recommended for Ingress)
+              value: "true"
+          # - name: KC_LOG_LEVEL
+          #   value: "DEBUG"
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "500m"
+            limits:
+              memory: "1Gi"
+              cpu: "1"
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 3
+  strategy:
+      # RollingUpdate strategy ensures zero-downtime during deployments by gradually updating pods
+    type: RollingUpdate
+    rollingUpdate:
+        # Allow creating max 1 pod above desired count during updates
+        # Example: If replicas=3, we can have 4 pods temporarily during update
+      maxSurge: 1
+        # Ensure no pods become unavailable during the update
+        # Forces new pods to be ready before removing old ones
+      maxUnavailable: 0
+
+---
+
+# Service
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-service
+  labels:
+    app: keycloak # groups this service with other Keycloak-related resources
+spec:
+  selector:
+    app: keycloak # Matches Deployment's label
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 8080 # The port other services use to access
+      targetPort: 8080
+
+      

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.3</version>
+        <version>3.4.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>iam</groupId>
@@ -28,8 +28,8 @@
     </scm>
     <properties>
         <java.version>17</java.version>
-        <spring-cloud.version>2023.0.3</spring-cloud.version>
-        <springdoc-openapi.version>2.3.0</springdoc-openapi.version>
+        <spring-cloud.version>2024.0.1</spring-cloud.version>
+        <springdoc-openapi.version>2.8.8</springdoc-openapi.version>
         <loki.version>1.5.1</loki.version>
         <maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
         <docker.image.name>isaacafrifa/bm-${project.artifactId}</docker.image.name>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <properties>
         <java.version>17</java.version>
         <spring-cloud.version>2023.0.3</spring-cloud.version>
-        <springdoc-openapi.version>2.5.0</springdoc-openapi.version>
+        <springdoc-openapi.version>2.3.0</springdoc-openapi.version>
         <loki.version>1.5.1</loki.version>
         <maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
         <docker.image.name>isaacafrifa/bm-${project.artifactId}</docker.image.name>
@@ -93,6 +93,21 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
+        <!-- Security -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <!--  The API Gateway acts as a protected resource that receives and validates access tokens issued by Keycloak-->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+        </dependency>
+        <!-- Security OAuth2 JOSE (JSON Object Signing and Encryption) support for JWT processing in reactive applications -->
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-jose</artifactId>
         </dependency>
     </dependencies>
     <dependencyManagement>

--- a/src/main/java/iam/apigateway/controller/GatewayController.java
+++ b/src/main/java/iam/apigateway/controller/GatewayController.java
@@ -1,23 +1,49 @@
 package iam.apigateway.controller;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @RestController
 public class GatewayController {
 
+    private static final Logger log = LoggerFactory.getLogger(GatewayController.class);
+
     @GetMapping("/usersFallback")
     public ResponseEntity<Object> userFallback() {
+       log.error("User service is currently unavailable");
         return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
                 .body("User service is currently unavailable. Please try again later.");
     }
 
+    @GetMapping("/userServiceDocsFallback")
+    public ResponseEntity<Map<String, String>> userServiceFallback() {
+        Map<String, String> response = new HashMap<>();
+        log.error("User service API documentation is currently unavailable");
+        response.put("message", "User service API documentation is currently unavailable. Please try again later.");
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(response);
+    }
+
+
     @GetMapping("/bookingsFallback")
     public ResponseEntity<Object> bookingFallback() {
+        log.error("Booking service is currently unavailable");
         return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
                 .body("Booking service is currently unavailable. Please try again later.");
+    }
+
+    @GetMapping("/bookingServiceDocsFallback")
+    public ResponseEntity<Map<String, String>> bookingServiceFallback() {
+        Map<String, String> response = new HashMap<>();
+        log.error("Booking service API documentation is currently unavailable");
+        response.put("message", "Booking service API documentation is currently unavailable. Please try again later.");
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(response);
     }
 
 }

--- a/src/main/java/iam/apigateway/security/SecurityConfig.java
+++ b/src/main/java/iam/apigateway/security/SecurityConfig.java
@@ -1,0 +1,94 @@
+package iam.apigateway.security;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.oauth2.jwt.ReactiveJwtDecoder;
+import org.springframework.security.oauth2.jwt.ReactiveJwtDecoders;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.reactive.CorsConfigurationSource;
+import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.List;
+
+/* Reactive security configuration */
+@Configuration
+@EnableWebFluxSecurity
+public class SecurityConfig {
+
+    @Value("${spring.security.oauth2.resourceserver.jwt.issuer-uri}")
+    private String issuerUri;
+
+    private final String[] allowedResourceUrls = {"/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**",
+            "/swagger-resources/**", "/api-docs/**", "/aggregate/**", "/actuator/**"};
+
+    /* Configure security filter chain:
+    1. All requests require authentication
+    2. Configure as OAuth2 resource server with JWT validation
+   Note: Currently using default JWT converter, will be replaced with KeycloakJwtAuthenticationConverter
+         for proper role/authority mapping from Keycloak tokens
+     */
+    @Bean
+    public SecurityWebFilterChain securityFilterChain(ServerHttpSecurity http) {
+        return http
+                .csrf(ServerHttpSecurity.CsrfSpec::disable)
+                .authorizeExchange(exchanges -> exchanges
+                        .pathMatchers(allowedResourceUrls).permitAll()
+                        .anyExchange().authenticated())
+                .oauth2ResourceServer(
+                        oauth2 -> oauth2.jwt(
+                                // jwt -> jwt.jwtAuthenticationConverter(new KeycloakJwtAuthenticationConverter()) // will explore this later
+                                Customizer.withDefaults()))
+                .build();
+    }
+
+
+
+
+    @Bean
+    public ReactiveJwtDecoder jwtDecoder() {
+        return ReactiveJwtDecoders.fromIssuerLocation(issuerUri);
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration corsConfig = new CorsConfiguration();
+        corsConfig.setAllowedOrigins(List.of("*"));
+        corsConfig.setMaxAge(3600L); // Cache preflight for 1 hour
+        corsConfig.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS", "HEAD"));
+        corsConfig.setAllowedHeaders(Arrays.asList(
+                "Authorization",
+                "Content-Type",
+                "Accept",
+                "X-Requested-With",
+                "Cache-Control"));
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", corsConfig);
+        return source;
+    }
+}
+
+
+
+/*  Will be explored later....
+* The KeycloakJwtAuthenticationConverter is specifically designed to:
+- Extract roles and permissions from Keycloak's token structure
+- Map Keycloak's role format to Spring Security authorities
+*/
+//public class KeycloakJwtAuthenticationConverter implements Converter<Jwt, AbstractAuthenticationToken> {
+//    @Override
+//    public AbstractAuthenticationToken convert(Jwt jwt) {
+//        // Extracts roles from Keycloak-specific claims like "realm_access" and "resource_access"
+//        Collection<GrantedAuthority> authorities = extractAuthorities(jwt);
+//
+//        // Creates a Spring Security authentication token with the extracted authorities
+//        return new JwtAuthenticationToken(jwt, authorities);
+//    }
+//}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,7 +21,7 @@ spring:
             predicates:
               - Path=/users/**
             filters:
-              - PrefixPath=/api/v1
+#              - PrefixPath=/api/v1
               - AddResponseHeader=X-Powered-By, IAM Gateway Service
               - name: CircuitBreaker
                 args:
@@ -33,7 +33,7 @@ spring:
             predicates:
               - Path=/bookings/**
             filters:
-              - PrefixPath=/api/v1
+#              - PrefixPath=/api/v1
               - AddResponseHeader=X-Powered-By, IAM Gateway Service
               - name: CircuitBreaker
                 args:
@@ -49,7 +49,7 @@ spring:
               - name: CircuitBreaker
                 args:
                   name: myCircuitBreaker
-                  fallbackUri: forward:/usersFallback
+                  fallbackUri: forward:/userServiceDocsFallback
           - id: booking-swagger-route
             uri:
               ${BOOKING_SERVICE_URL:http://localhost:8081}
@@ -60,7 +60,23 @@ spring:
               - name: CircuitBreaker
                 args:
                   name: myCircuitBreaker
-                  fallbackUri: forward:/bookingsFallback
+                  fallbackUri: forward:/bookingServiceDocsFallback
+  ### Security Props
+  security:
+    oauth2:
+      resourceserver:
+        # JWT Validation Flow:
+        # 1. Spring Security receives the JWT token
+        # 2. Fetches public keys (JWKS) from jwk-set-uri endpoint
+        # 3. Uses matching public key (by 'kid' header) to verify signature
+        # 4. Validates standard claims (exp, iat, iss, etc.)
+        jwt:
+          # The issuer-uri specifies the identity provider (i.e. Keycloak) that issues the JWT tokens
+          # Spring Security uses this to validate the 'iss' claim in the JWT
+          issuer-uri: ${KEYCLOAK_JWT_ISSUER_URI:http://localhost:8080/realms/bookme-realm}
+          # This endpoint provides the public keys needed to verify the JWT signatures
+          # Spring Security automatically fetches these keys to validate that the tokens were actually signed by our Keycloak server
+          jwk-set-uri: ${KEYCLOAK_JWK_SET_URI:http://localhost:8080/realms/bookme-realm/protocol/openid-connect/certs}
 
 ## API docs props
 springdoc:
@@ -83,6 +99,8 @@ management:
           health, info, metrics, prometheus
   endpoint:
     health:
+      probes:
+        enabled: true
       show-details: always
       ## allow downstream apis to access the actuator of this api gateway
     gateway:


### PR DESCRIPTION
- Added infrastructure for Keycloak
- Implemented security in the API gateway. Don't forget the API-gateway uses webflux, not MVC, so changes were made to the SecurityConfig class.
- Added a readme file to describe how to test the API-Gateway after implementing security.
- Reduced keycloak resource limits and updated readiness probe times
- Updated the dependency versions of Spring Boot, Spring Cloud, and Springdoc Openapi