### PR TITLE
refactor(k8s): update k8s configurations for bookme infrastructure

### DIFF
--- a/k8s/infra/grafana.yaml
+++ b/k8s/infra/grafana.yaml
@@ -16,6 +16,14 @@ spec:
       containers:
         - name: grafana
           image: grafana/grafana:10.1.0
+          # Lower resources ideal for local dev. Adjust as needed for testing or production workloads.
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "200m"
           ports:
             - containerPort: 3000   # Main Grafana UI and API port
           # Environment variables for Grafana configuration. These enable anonymous access for development purposes
@@ -35,6 +43,24 @@ spec:
                 configMapKeyRef:
                   key: GF_AUTH_DISABLE_LOGIN_FORM
                   name: grafana-configmap
+          # Liveness probe to check Grafana's health endpoint
+          # Determines if the pod should be restarted when unhealthy
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: 3000
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            failureThreshold: 3
+          # Readiness probe to check Grafana's ready endpoint
+          # Ensures the pod is ready to handle traffic
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 3
           volumeMounts: # Mount point for datasource configuration
             - name: grafana-config
               mountPath: /etc/grafana/provisioning/datasources
@@ -88,7 +114,7 @@ data:
           exemplarTraceIdDestinations:
             - name: trace_id
               datasourceUid: tempo
-      
+
       # Tempo datasource configuration
       # Used for distributed tracing
       - name: Tempo
@@ -108,7 +134,7 @@ data:
             datasourceUid: 'loki'
           nodeGraph:
             enabled: true
-      
+
       # Loki datasource configuration
       # Used for log aggregation and querying
       - name: Loki

--- a/k8s/infra/loki.yaml
+++ b/k8s/infra/loki.yaml
@@ -18,10 +18,36 @@ spec:
       containers:
         - name: loki
           image: grafana/loki:main
+          # Lower resources ideal for local dev. Adjust as needed for testing or production workloads.
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "200m"
           ports:
             - containerPort: 3100
           # Provide command-line arguments to the Loki server
           args: ["-config.file=/etc/loki/local-config.yaml"]
+          # Liveness probe to check Loki's health endpoint
+          # Determines if the pod should be restarted when unhealthy
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: 3100
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 3
+          # Readiness probe to check Loki's ready endpoint
+          # Ensures the pod is ready to handle traffic
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 3100
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            failureThreshold: 3
 
 ---
 

--- a/k8s/infra/prometheus.yaml
+++ b/k8s/infra/prometheus.yaml
@@ -16,6 +16,14 @@ spec:
       containers:
         - name: prometheus
           image: prom/prometheus:v2.46.0
+          # Lower resources ideal for local dev. Adjust as needed for testing or production workloads.
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "200m"
           ports:
             - containerPort: 9090  # Default Prometheus port
           args:
@@ -24,6 +32,24 @@ spec:
           volumeMounts:
             - name: prometheus-config
               mountPath: /etc/prometheus  # Mount point for Prometheus configuration
+          # Liveness probe to check Prometheus's health endpoint
+          # Determines if the pod should be restarted when unhealthy
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: 9090
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 3
+          # Readiness probe to check Prometheus's ready endpoint
+          # Ensures the pod is ready to handle traffic
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 9090
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            failureThreshold: 3
       volumes:
         - name: prometheus-config
           configMap:

--- a/k8s/infra/rabbitmq.yaml
+++ b/k8s/infra/rabbitmq.yaml
@@ -18,6 +18,14 @@ spec:
         - name: rabbitmq
           image: rabbitmq:management
           imagePullPolicy: IfNotPresent
+          # Lower resources ideal for local dev. Adjust as needed for testing or production workloads.
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "200m"
           ports:
             - containerPort: 5672
               name: amqp
@@ -49,6 +57,24 @@ spec:
                 configMapKeyRef:
                   name: infra-config
                   key: RABBITMQ_MANAGEMENT_PORT
+        # Liveness probe to check RabbitMQ's health checks endpoint
+        # Determines if the pod should be restarted when unhealthy
+          livenessProbe:
+            httpGet:
+              path: /  # Root path to check if RabbitMQ management is up
+              port: 15672
+            initialDelaySeconds: 60 # Delay before the first check
+            periodSeconds: 10   # Check every 10 seconds
+            failureThreshold: 3  # Restart after 3 failures
+        # Readiness probe to check RabbitMQ's health checks endpoint
+        # Ensures the pod is ready to handle traffic
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 15672
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 3
 
 ---
 
@@ -70,4 +96,3 @@ spec:
       port: 15672
       targetPort: 15672
   type: ClusterIP
-      

--- a/k8s/infra/tempo.yaml
+++ b/k8s/infra/tempo.yaml
@@ -17,6 +17,14 @@ spec:
       containers:
         - name: tempo
           image: grafana/tempo:2.2.2  # Using specific version for stability
+          # Lower resources ideal for local dev. Adjust as needed for testing or production workloads.
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "200m"
           args:
             - '-config.file=/etc/tempo/tempo.yaml' # Points to the mounted config file from ConfigMap
           ports:


### PR DESCRIPTION
### **Description**
This PR updates and refines the Kubernetes configurations for **Grafana**, **Loki**, **Prometheus**, **RabbitMQ**, and **Tempo** to enhance the reliability of liveness and readiness probes. These changes improve service availability and ensure accurate health checks during deployment and runtime.
Additionally, this PR reduces the infrastructure's **resource limits and requests** to make the setup more suitable for local development environments.

### **Key Changes**
- Updated liveness and readiness probes:
    - **Improved reliability** by adjusting `initialDelaySeconds`, probe paths, and other configurations.
    - Modified probe settings for **Grafana**, **Loki**, **Prometheus**, **RabbitMQ**, and **Tempo**.

- Reduced **resource limits and requests**:
    - Optimized resources for local development to reduce overhead and improve usability.
