### PR TITLE
feat: Add Keycloak and API Gateway ingress manifests with documentation

### DIFF
--- a/k8s/AuthReadMe.md
+++ b/k8s/AuthReadMe.md
@@ -1,0 +1,106 @@
+# Authentication Flow
+This document explains the authentication flow with Keycloak, the API Gateway, and microservices. It highlights both **external access** for the React app and **internal access** for services running inside the Kubernetes cluster.
+
+---
+
+## Overview
+
+- **React App** (External)
+    - It accesses the Keycloak server via **Ingress** (`auth.dashboard.com`).
+    - Uses the Keycloak public URLs for authentication (token requests, login redirects).
+
+- **API Gateway & Microservices** (Internal)
+    - They access Keycloak via **internal ClusterIP service** (`keycloak-service:80`).
+    - Uses `KEYCLOAK_JWT_ISSUER_URI` and `KEYCLOAK_JWK_SET_URI` pointing to the internal service URL.
+    - The gateway validates JWTs for all incoming requests to microservices.
+
+- **DNS Resolution**
+    - **External React App** uses public hostnames resolved via standard local DNS (`auth.dashboard.com`) in `/etc/host`
+    - **Internal Services** (gateway, users, bookings) use **internal Kubernetes DNS**:
+        - Updated via CoreDNS config in minikube for local development.
+        - Maps `auth.dashboard.com` to `keycloak-service` IP internally.
+
+---
+
+## Internal vs External Flows
+
+### 1. External Flow (React App → Keycloak Ingress)
+
+Browser (React App)
+        |
+        v
++------------------+
+| Keycloak Ingress |
+| auth.dashboard.com|
++------------------+
+        |
+        v
+Keycloak Service
+        |
+        v
+Keycloak Pod
+
+
+- External clients access `auth.dashboard.com` (via minikube tunnel or production ingress).
+- Keycloak issues JWTs that include the issuer as `http://auth.dashboard.com/realms/bookme-realm`.
+
+---
+
+### 2. Internal Flow (Gateway / Microservices → Keycloak Service)
+
+API Gateway / Microservice
+        |
+        v
++-------------------+
+| Keycloak Service |
+| keycloak-service |
++-------------------+
+        |   
+        v
+Keycloak Pod
+
+
+
+- Internal services do **not go through the ingress**.
+- Use the ClusterIP service (`keycloak-service:80`) for token validation and JWKS fetching.
+- Ensures internal communication works even if the ingress is restricted to external access only.
+
+---
+
+## Configuration Notes
+
+- **Keycloak Service (ClusterIP)**:
+
+```yaml
+ports:
+  - protocol: TCP
+    port: 80        # Default HTTP port
+    targetPort: 8080
+```
+
+### Internal URLs for Gateway:
+```
+KEYCLOAK_JWT_ISSUER_URI: "http://auth.dashboard.com/realms/bookme-realm"
+KEYCLOAK_JWK_SET_URI: "http://auth.dashboard.com/realms/bookme-realm/protocol/openid-connect/certs"
+```
+- Thanks to my CoreDNS override in minikube, pods can still reach that host internally without hitting the Ingress.
+
+### External URLs for React App:
+```
+VITE_KEYCLOAK_URL=http://auth.dashboard.com
+```
+
+#### CoreDNS (minikube) mapping for internal resolution:
+```
+hosts {
+    10.106.129.56 auth.dashboard.com
+    fallthrough
+}
+```
+- Note that the 10.106.129.56 is the ClusterIP of the keycloak service
+
+### Benefits of This Approach
+- External apps can authenticate via standard ingress URLs without exposing internal services.
+- Internal services can validate JWTs directly using the ClusterIP service, bypassing ingress.
+- No 401 Unauthorized issues due to unreachable issuer URLs from internal pods.
+- Keeps internal and external traffic separated for better security and flexibility.

--- a/k8s/api-gateway/gateway-ingress.yaml
+++ b/k8s/api-gateway/gateway-ingress.yaml
@@ -1,0 +1,31 @@
+# API Gateway Ingress
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: gateway-ingress
+  namespace: default
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"  # dev only; enable with TLS in prod
+    nginx.ingress.kubernetes.io/proxy-body-size: "10m" # increase if importing large realms
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /$1 #preserve the full sub‑path to the gateway e.g. Request → /users/123 and Backend receives → /users/123
+spec:
+  ingressClassName: nginx
+  rules:
+    - http:
+        paths:
+          - path: /(.*)  # regex: capture and preserve full subpath via rewrite
+            pathType: ImplementationSpecific  # regex paths require ImplementationSpecific
+            backend:
+              service:
+                name: gateway-service
+                port:
+                  number: 9000
+# TLS (production):
+# To enable HTTPS at the ingress, add a tls section like below and set ssl-redirect to "true" or remove it.
+# NOTE: Using host-agnostic 'regex path' and 'rewrite' preserves subpaths and avoids requiring DNS/TLS in dev.
+#       In production, prefer a host-specific Ingress with pathType: Prefix (no rewrite) and TLS enabled.
+# tls:
+#   - hosts:
+#       - api.bookme.com
+#     secretName: gateway-tls  # pre-created TLS secret containing cert/key for the host

--- a/k8s/infra/infra-config.yaml
+++ b/k8s/infra/infra-config.yaml
@@ -19,5 +19,11 @@ data:
   GATEWAY_SERVICE_URL: "http://gateway-service.default.svc.cluster.local:9000"
   # Keycloak
   KEYCLOAK_DB_NAME: "keycloak-db"
-  KEYCLOAK_JWT_ISSUER_URI: "http://keycloak-service:8080/realms/bookme-realm"
-  KEYCLOAK_JWK_SET_URI: "http://keycloak-service:8080/realms/bookme-realm/protocol/openid-connect/certs"
+  # Internal service pods (Gateway, User, etc.) can use http://auth.dashboard.com for issuer-uri and jwk-set-uri
+  # because I updated the CoreDNS in Minikube which resolves auth.dashboard.com to the keycloak-service ClusterIP.
+  KEYCLOAK_JWT_ISSUER_URI: "http://auth.dashboard.com/realms/bookme-realm"
+  KEYCLOAK_JWK_SET_URI: "http://auth.dashboard.com/realms/bookme-realm/protocol/openid-connect/certs"
+  # Keycloak config supposed to be used in the frontend dashboard app
+  KEYCLOAK_REALM: "bookme-realm"
+  KEYCLOAK_CLIENT_ID: "bookme-dashboard"
+  KEYCLOAK_HOSTNAME: "auth.dashboard.com"

--- a/k8s/infra/keycloak/keycloak-app.yaml
+++ b/k8s/infra/keycloak/keycloak-app.yaml
@@ -125,5 +125,5 @@ spec:
   type: ClusterIP
   ports:
     - protocol: TCP
-      port: 8080 # Port that other services in the cluster will use to connect to this service
+      port: 80 # Port that other services in the cluster will use to connect to this service
       targetPort: 8080 # Port on the Keycloak container where the application is actually running

--- a/k8s/infra/keycloak/keycloak-ingress.yaml
+++ b/k8s/infra/keycloak/keycloak-ingress.yaml
@@ -1,0 +1,30 @@
+# Keycloak Ingress (NGINX) — minimal config
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: keycloak-ingress
+  namespace: default
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"  # dev only; enable with TLS in prod
+    nginx.ingress.kubernetes.io/proxy-body-size: "10m"  # increase if importing large realms
+    nginx.ingress.kubernetes.io/rewrite-target: /$1     # keep subpath from /(.*)
+    nginx.ingress.kubernetes.io/use-regex: "true"      # required by regex path below
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: auth.dashboard.com
+      http:
+        paths:
+          - path: /(.*)
+            pathType: ImplementationSpecific  # regex paths require ImplementationSpecific
+            backend:
+              service:
+                name: keycloak-service
+                port:
+                  number: 8080
+# TLS (production):
+# To enable HTTPS at the ingress, add a tls section like below and set ssl-redirect to "true" or remove it.
+# tls:
+#   - hosts:
+#       - auth.dashboard.com
+#     secretName: keycloak-tls  # pre-created TLS secret containing cert/key for the host


### PR DESCRIPTION
### Description of Changes

- **Feature Enhancements:**  
  - Introduced ingress manifests for NGINX ingress management (`gateway-ingress.yaml` and `keycloak-ingress.yaml`).  
  - Updated Keycloak service to use port 80 for hostname-based routing (`auth.dashboard.com`).  
  - Adjusted Keycloak environment variables in `infra-config.yaml` accordingly.  

- **Documentation Updates:**  
  - Added a README to explain authentication flows for Keycloak, API Gateway, and microservices.  
  - Covered external access for the React frontend, internal access via ClusterIP service, configuration details, DNS setup, and benefits of the approach.

### Checklist

- [x] Ensure backward compatibility with existing configurations.
- [x] Validate ingress functionality in both local and production environments.
- [x] Update deployment documentation with ingress usage details.